### PR TITLE
bump deps (fix  prototype pollution in lodash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "author": "Ankur Oberoi <aoberoi@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "tap": "^0.6.0"
+    "tap": "^11.1.5"
   },
   "dependencies": {
-    "lodash": "^3.2.0",
+    "lodash": "^4.17.10",
     "nonce": "^1.0.3",
-    "unix-timestamp": "^0.1.2"
+    "unix-timestamp": "^0.2.0"
   }
 }


### PR DESCRIPTION
- fix prototype pollution in lodash (https://nodesecurity.io/advisories/577)
- bump other deps (tap, unix-timestamp)